### PR TITLE
Updated timeit routine to return the min_of_n at a default value of 3

### DIFF
--- a/experiments/experiments.py
+++ b/experiments/experiments.py
@@ -613,15 +613,15 @@ class Experiment:
 
 def main():
     e = Experiment()
-    # e.time_phot_shooting_vs_gal_size()
-    # e.time_phot_shooting_vs_gal_shape()
-    # e.time_phot_shooting_vs_profile()
+    e.time_phot_shooting_vs_gal_size()
+    e.time_phot_shooting_vs_gal_shape()
+    e.time_phot_shooting_vs_profile()
     e.time_phot_shooting_vs_psf()
     e.time_phot_shooting_vs_optical_psf_params()
-    # e.time_phot_shooting_vs_optical_psf_vary_obscuration()
-    # e.time_phot_shooting_vs_optical_psf_vary_lam_over_diam()
-    # e.fft_image_size_vs_flux_vary_lam_over_diam()
-    # e.get_PSF_FWHM()
+    e.time_phot_shooting_vs_optical_psf_vary_obscuration()
+    e.time_phot_shooting_vs_optical_psf_vary_lam_over_diam()
+    e.fft_image_size_vs_flux_vary_lam_over_diam()
+    e.get_PSF_FWHM()
 
 if __name__ == "__main__":
     main()

--- a/timer/core.py
+++ b/timer/core.py
@@ -268,7 +268,7 @@ class Timer:
             else:
                 temp_params["half_light_radius"] += rand_offset
 
-            gal, time_gal = timeit(self.cur_gal_name_constructor, repeat=repeat)(**temp_params)
+            gal, time_gal = timeit(self.cur_gal_name_constructor, min_of_n=repeat)(**temp_params)
             
             self.init_times.append(time_gal)
             self.cur_gal_objs.append(gal)

--- a/timer/helpers.py
+++ b/timer/helpers.py
@@ -1,34 +1,34 @@
 import time
 import galsim
 from astropy.io import fits
+import sys
 
 
-def timeit(func, repeat : int = 1):
+def timeit(func, min_of_n : int = 3):
     """
     Takes in a function func and rusn it on the arguments 
     provided. Outputs the output of func(*args) and the time taken.
-    If repeat is an integer > 1, then it repeats the routine
-    `repeat` number of times and outputs the average amount of time 
+    If min_of_n is an integer > 1, then it repeats
+    `min_of_n` number of times and outputs the minimum amount of time 
     taken.
     """
 
-    if repeat < 1:
-        raise ValueError("repeat parameter cannot be less than 1.")
+    if min_of_n < 1:
+        raise ValueError("min_of_n parameter cannot be less than 1.")
 
     def timeit_wrapper(*args, **kwargs):
-        average = 0
+        min_time = sys.maxsize # big, unfeasible number for a timeit experiment
 
-        for _ in range(repeat):
+        for _ in range(min_of_n):
 
             tstart = time.time()
             res = func(*args, **kwargs)
             tend = time.time()
             duration = tend - tstart
 
-            average += duration
+            if duration <= min_time:
+                min_time = duration
 
-        average /= repeat
-
-        return res, average
+        return res, min_time
 
     return timeit_wrapper


### PR DESCRIPTION
Updated `timeit` routine to include a `min_of_n` parameter instead of a `repeat` parameter where we take the minimum time of 3 runs as opposed to the average as suggested by Mike Jarvis.