### PR TITLE
Fftdrawtime v image size

### DIFF
--- a/experiments/experiments.py
+++ b/experiments/experiments.py
@@ -9,7 +9,7 @@ import os
 from pathlib import Path
 
 # DEBUGGING TOOLS #
-import pdb
+# import pdb
 # END DEBUGING TOOLS #
 
 class Experiment:
@@ -1079,7 +1079,6 @@ class Experiment:
             # If the data contains an array of strings
             # dtype("<U1") is what numpy uses to indicate if an numpy array
             # contains strings
-            # pdb.set_trace()
             if np.array(varied_data).dtype == np.dtype("<U1"):
                 x = np.arange(len(varied_data))
                 y = image_sizes

--- a/experiments/experiments.py
+++ b/experiments/experiments.py
@@ -39,6 +39,10 @@ class Experiment:
             "generated_images"
         )
 
+        self.fft_draw_times = []
+        self.fft_draw_time_stdev = []
+        self.fft_image_sizes = []
+
         self.default_flux_range = default_flux_range
 
 
@@ -135,6 +139,10 @@ class Experiment:
         axs[1].legend(legend_labels)
 
         fft_draw_time_title = "FFT Drawing Time vs. Image Size\nExperiment 1: Varying half_light_radius"
+
+        self.fft_draw_times.extend(fft_draw_times)
+        self.fft_draw_time_stdev.extend(fft_draw_times)
+        self.fft_image_sizes.extend(fft_image_sizes)
         
         self.plot_fft_draw_time_vs_image_size(
             fft_draw_times,
@@ -142,7 +150,8 @@ class Experiment:
             fft_image_sizes,
             1,
             title=fft_draw_time_title,
-            varied_data=half_light_radii
+            varied_data=half_light_radii,
+            varied_data_label="half_light_radius"
         )
 
         if self.show:
@@ -778,7 +787,8 @@ class Experiment:
 
 
     def plot_fft_draw_time_vs_image_size(self, draw_times, stdevs, image_sizes, 
-                                         exp_number, title="", varied_data=None):
+                                         exp_number, title="", varied_data=None,
+                                         varied_data_label=""):
         """
         This routine takes in a list of draw times, stdevs, and image sizes and 
         plots them.

--- a/experiments/experiments.py
+++ b/experiments/experiments.py
@@ -382,6 +382,7 @@ class Experiment:
             - Plot instantiation time and convolution time for each flux value on different convolutions
               with different PSFs.
         """
+        exp_num = 4
         if plot is None:
             fig, axs = plt.subplots(1, 2)
         else:
@@ -392,6 +393,10 @@ class Experiment:
 
         galaxy = "sersic"
         lines = []
+
+        fft_draw_times = []
+        fft_draw_time_stdev = []
+        fft_image_sizes = []
 
         for psf in Timer.PSFS:
             t = Timer(galaxy, flux_range=self.default_flux_range)
@@ -406,6 +411,22 @@ class Experiment:
 
             t.plot_draw_times(axis=draw_axis)
 
+            # Running FFT drawing time routine.
+
+            # This is to make sure that the compute_phot_draw_times routine in 
+            # core is idempotent. We test this comparing the output of that 
+            # routine on a new object vs an object that we have already run
+            # that routine on. Uncomment the following 3 lines 
+            # if you want to run this test.
+
+            # t = Timer(galaxy, flux_range=self.default_flux_range, **params)
+            # t.time_init()
+            # t.set_psf(psf)
+
+            self.compute_fft_draw_time_stats(
+                t, fft_draw_times, fft_draw_time_stdev, fft_image_sizes
+            )
+
         temp_labels = [(psf+" %s" % method) for psf in Timer.PSFS]
         
         title1 = "Time vs. Photon Shooting for Sersic Profile Convolved with Various PSFs"
@@ -417,6 +438,19 @@ class Experiment:
 
         axs[0].legend(legend_labels)
         axs[1].legend(legend_labels)
+
+        self.fft_draw_times.extend(fft_draw_times)
+        self.fft_draw_time_stdev.extend(fft_draw_times)
+        self.fft_image_sizes.extend(fft_image_sizes)
+        
+        self.plot_fft_draw_time_vs_image_size(
+            fft_draw_times,
+            fft_draw_time_stdev,
+            fft_image_sizes,
+            exp_num,
+            varied_data=list(Timer.PSFS.values()),
+            varied_data_label="PSF"
+        )
 
         if self.show:
             plt.show()
@@ -978,8 +1012,8 @@ def main():
 
     # e.time_vs_flux_on_gal_size()
     # e.time_vs_flux_on_gal_shape()
-    e.time_vs_flux_on_profile()
-    # e.time_vs_flux_on_psf()
+    # e.time_vs_flux_on_profile()
+    e.time_vs_flux_on_psf()
     # e.time_vs_flux_on_optical_psf_params()
     # e.time_vs_flux_on_optical_psf_vary_obscuration()
     # e.time_vs_flux_on_optical_psf_vary_lam_over_diam()

--- a/experiments/experiments.py
+++ b/experiments/experiments.py
@@ -85,10 +85,22 @@ class Experiment:
             t.time_init()
             t.set_psf(psf)
             t.compute_phot_draw_times(method=method)
+
             best_fit_equations.append(t.draw_time_line_annotation)
+            # algorithm:
+            # run t.compute_phot_draw_times(method="fft")
+            # - get the fft times
+            #   - compute the average and std deviation
+            # - compute the image size
+            # - add the fft average time to a list of average times
+            # - add the fft std dev to a list of std dev times
+            # - add the image size to a list of image times
 
             t.plot_init_times(axis=init_ax)
             t.plot_draw_times(axis=draw_ax)
+
+        # plot the image times vs image size using the std dev list as the 
+        # error bars
 
         legend_labels.extend(["r = %f\n%s %s" % (r, annotation, method) for (r, annotation) in zip(half_light_radii, best_fit_equations)])
 
@@ -758,7 +770,8 @@ class PhotonAndFFTPlottingExperiment(Experiment):
         labels = get_axis_legend_labels(plots[6][1][1])
         self.save = True
         self.time_vs_flux_on_optical_psf_vary_lam_over_diam(method="fft", plot=plots[6], legend_labels=labels)
-        
+
+
 
 def main():
     e = PhotonAndFFTPlottingExperiment(exp_dat_dir="testing_horizontals")

--- a/experiments/experiments.py
+++ b/experiments/experiments.py
@@ -119,10 +119,9 @@ class Experiment:
             # t.time_init()
             # t.set_psf(psf)
 
-            fft_draw_stats = self.compute_fft_draw_time_stats(t)
-            fft_draw_times.append(fft_draw_stats["mean_draw_time"])
-            fft_draw_time_stdev.append(fft_draw_stats["draw_time_stdev"])
-            fft_image_sizes.append(fft_draw_stats["image_size"])
+            self.compute_fft_draw_time_stats(
+                t, fft_draw_times, fft_draw_time_stdev, fft_image_sizes
+            )
 
         # plot the image times vs image size using the std dev list as the 
         # error bars
@@ -762,7 +761,8 @@ class Experiment:
         print("Saving %s" % filename)
 
 
-    def compute_fft_draw_time_stats(self, t):
+    def compute_fft_draw_time_stats(self, t, fft_draw_times, fft_draw_time_stdev,
+                                    fft_image_sizes):
         """
         This routine takes in timer:Timer object that contains the results of 
         having completed the FFT drawing routines. We use this to compute
@@ -783,7 +783,10 @@ class Experiment:
         draw_time_stdev = np.std(draw_times)
         dat["draw_time_stdev"] = draw_time_stdev
 
-        return dat
+        fft_draw_times.append(dat["mean_draw_time"])
+        fft_draw_time_stdev.append(dat["draw_time_stdev"])
+        fft_image_sizes.append(dat["image_size"])
+
 
 
     def plot_fft_draw_time_vs_image_size(self, draw_times, stdevs, image_sizes, 

--- a/experiments/experiments.py
+++ b/experiments/experiments.py
@@ -1,6 +1,7 @@
 from timer import Timer
 from timer.helpers import get_axis_legend_labels
 import matplotlib.pyplot as plt
+import matplotlib.ticker as mtick
 import numpy as np
 import galsim
 from scipy import stats
@@ -1039,9 +1040,11 @@ class Experiment:
         fontsize = 24
         marker_size = 250
 
-        ax.errorbar(image_sizes, np.array(draw_times)*10**6,
-                    yerr=np.array(stdevs)*10**6, fmt="o", 
+        ax.errorbar(image_sizes, np.array(draw_times),
+                    yerr=np.array(stdevs), fmt="o", 
                     markersize=marker_size/10)
+
+        ax.yaxis.set_major_formatter(mtick.FormatStrFormatter("%.2e"))
 
         if title == "":
             if exp_number == 9:
@@ -1055,7 +1058,7 @@ class Experiment:
 
         ax.set_title(title, fontsize=fontsize)
         ax.set_xlabel("Image Size (Pixels)", fontsize=fontsize)
-        ax.set_ylabel(r"Time ($\mu$s)", fontsize=fontsize)
+        ax.set_ylabel("Time (s)", fontsize=fontsize)
 
         ax.tick_params(labelsize=24)
         ax.grid(True)
@@ -1085,6 +1088,8 @@ class Experiment:
                 ax.set_xticklabels(xtick_labels)
             else:
                 ax.scatter(varied_data, image_sizes, marker_size)
+
+            ax.yaxis.set_major_formatter(mtick.FormatStrFormatter("%03d"))
 
             ax.tick_params(labelsize=24)
             ax.grid(True)

--- a/experiments/experiments.py
+++ b/experiments/experiments.py
@@ -456,7 +456,7 @@ class Experiment:
             plt.show()
 
         if self.save:
-            self.save_figure(fig, 4)
+            self.save_figure(fig, exp_num)
 
 
     def time_vs_flux_on_optical_psf_params(self, method="phot", plot:tuple=None, legend_labels=[]):
@@ -476,7 +476,7 @@ class Experiment:
 
         Results: No dependence on aberration
         """
-
+        exp_num = 5
         # Include defocus, astigmatism, coma, and trefoil
 
         defocus = [0.0] * 12
@@ -500,6 +500,14 @@ class Experiment:
             spherical
         ]
 
+        aberrations_labels = [
+            "None",
+            "Defocus",
+            "Astigmatism",
+            "Coma",
+            "Spherical",
+        ]
+
         if plot is None:
             fig, axs = plt.subplots(1, 2)
         else:
@@ -512,6 +520,10 @@ class Experiment:
         psf = "optical"
 
         lines = []
+
+        fft_draw_times = []
+        fft_draw_time_stdev = []
+        fft_image_sizes = []
 
         for aberrations in aberrations_list:
 
@@ -529,6 +541,22 @@ class Experiment:
             lines.append(t.draw_time_line_annotation)
 
             t.plot_draw_times(axis=draw_axis)
+
+            # Running FFT drawing time routine.
+
+            # This is to make sure that the compute_phot_draw_times routine in 
+            # core is idempotent. We test this comparing the output of that 
+            # routine on a new object vs an object that we have already run
+            # that routine on. Uncomment the following 3 lines 
+            # if you want to run this test.
+
+            # t = Timer(galaxy, flux_range=self.default_flux_range, **params)
+            # t.time_init()
+            # t.set_psf(psf)
+
+            self.compute_fft_draw_time_stats(
+                t, fft_draw_times, fft_draw_time_stdev, fft_image_sizes
+            )
 
 
         temp_labels = [
@@ -551,6 +579,19 @@ class Experiment:
 
         axs[0].legend(legend_labels)
         axs[1].legend(legend_labels)
+
+        self.fft_draw_times.extend(fft_draw_times)
+        self.fft_draw_time_stdev.extend(fft_draw_times)
+        self.fft_image_sizes.extend(fft_image_sizes)
+        
+        self.plot_fft_draw_time_vs_image_size(
+            fft_draw_times,
+            fft_draw_time_stdev,
+            fft_image_sizes,
+            exp_num,
+            varied_data=aberrations_labels,
+            varied_data_label="Aberrations"
+        )
 
         if self.show:
             plt.show()
@@ -1013,8 +1054,8 @@ def main():
     # e.time_vs_flux_on_gal_size()
     # e.time_vs_flux_on_gal_shape()
     # e.time_vs_flux_on_profile()
-    e.time_vs_flux_on_psf()
-    # e.time_vs_flux_on_optical_psf_params()
+    # e.time_vs_flux_on_psf()
+    e.time_vs_flux_on_optical_psf_params()
     # e.time_vs_flux_on_optical_psf_vary_obscuration()
     # e.time_vs_flux_on_optical_psf_vary_lam_over_diam()
     # e.fft_image_size_vs_flux_vary_lam_over_diam()

--- a/experiments/experiments.py
+++ b/experiments/experiments.py
@@ -618,6 +618,7 @@ class Experiment:
             - Plot instantiation time and convolution time for each flux value on different convolutions
               for 2 different lam_over_diam parameters.
         """
+        exp_num = 6
 
         if plot is None:
             fig, axs = plt.subplots(1, 2)
@@ -633,6 +634,10 @@ class Experiment:
         obscurations = np.linspace(0, 0.5, 5)
 
         lines = []
+
+        fft_draw_times = []
+        fft_draw_time_stdev = []
+        fft_image_sizes = []
 
         for obscuration in obscurations:
 
@@ -651,6 +656,22 @@ class Experiment:
 
             t.plot_draw_times(axis=draw_axis)
 
+            # Running FFT drawing time routine.
+
+            # This is to make sure that the compute_phot_draw_times routine in 
+            # core is idempotent. We test this comparing the output of that 
+            # routine on a new object vs an object that we have already run
+            # that routine on. Uncomment the following 3 lines 
+            # if you want to run this test.
+
+            # t = Timer(galaxy, flux_range=self.default_flux_range, **params)
+            # t.time_init()
+            # t.set_psf(psf)
+
+            self.compute_fft_draw_time_stats(
+                t, fft_draw_times, fft_draw_time_stdev, fft_image_sizes
+            )
+
 
         temp_labels = ["obscuration = %f %s" % (o, method) for o in obscurations]
 
@@ -662,11 +683,24 @@ class Experiment:
 
         draw_axis.legend(legend_labels)
 
+        self.fft_draw_times.extend(fft_draw_times)
+        self.fft_draw_time_stdev.extend(fft_draw_times)
+        self.fft_image_sizes.extend(fft_image_sizes)
+        
+        self.plot_fft_draw_time_vs_image_size(
+            fft_draw_times,
+            fft_draw_time_stdev,
+            fft_image_sizes,
+            exp_num,
+            varied_data=obscurations,
+            varied_data_label="Obscurations"
+        )
+
         if self.show:
             plt.show()
 
         if self.save:
-            self.save_figure(fig, 6)
+            self.save_figure(fig, exp_num)
 
 
     def time_vs_flux_on_optical_psf_vary_lam_over_diam(self, method="phot", plot:tuple=None, legend_labels=[]):
@@ -685,7 +719,8 @@ class Experiment:
             - One repetition
             - Plot instantiation time and convolution time for each flux value on different convolutions
               for 2 different lam_over_diam parameters.
-        """                
+        """
+        exp_num = 7
         if plot is None:
             fig, axs = plt.subplots(1, 2)
         else:
@@ -705,6 +740,10 @@ class Experiment:
         lam_over_diams = np.linspace(0.1, 5., 5) * lod
 
         lines = []
+
+        fft_draw_times = []
+        fft_draw_time_stdev = []
+        fft_image_sizes = []
 
         for lam_over_diam in lam_over_diams:
             
@@ -730,6 +769,22 @@ class Experiment:
 
             t.plot_draw_times(axis=draw_axis)
 
+            # Running FFT drawing time routine.
+
+            # This is to make sure that the compute_phot_draw_times routine in 
+            # core is idempotent. We test this comparing the output of that 
+            # routine on a new object vs an object that we have already run
+            # that routine on. Uncomment the following 3 lines 
+            # if you want to run this test.
+
+            # t = Timer(galaxy, flux_range=self.default_flux_range, **params)
+            # t.time_init()
+            # t.set_psf(psf)
+
+            self.compute_fft_draw_time_stats(
+                t, fft_draw_times, fft_draw_time_stdev, fft_image_sizes
+            )
+
 
         temp_labels = ["lam_over_diam = %f arcsecs %s" % (lod, method) for lod in lam_over_diams]
 
@@ -741,11 +796,24 @@ class Experiment:
         init_axis.legend(legend_labels)
         draw_axis.legend(legend_labels)
 
+        self.fft_draw_times.extend(fft_draw_times)
+        self.fft_draw_time_stdev.extend(fft_draw_times)
+        self.fft_image_sizes.extend(fft_image_sizes)
+        
+        self.plot_fft_draw_time_vs_image_size(
+            fft_draw_times,
+            fft_draw_time_stdev,
+            fft_image_sizes,
+            exp_num,
+            varied_data=lam_over_diams,
+            varied_data_label="lam/diam"
+        )
+
         if self.show:
             plt.show()
 
         if self.save:
-            self.save_figure(fig, 7)
+            self.save_figure(fig, exp_num)
 
 
     def fft_image_size_vs_flux_vary_lam_over_diam(self, method="phot", plot:tuple=None):
@@ -1055,9 +1123,9 @@ def main():
     # e.time_vs_flux_on_gal_shape()
     # e.time_vs_flux_on_profile()
     # e.time_vs_flux_on_psf()
-    e.time_vs_flux_on_optical_psf_params()
-    # e.time_vs_flux_on_optical_psf_vary_obscuration()
-    # e.time_vs_flux_on_optical_psf_vary_lam_over_diam()
+    # e.time_vs_flux_on_optical_psf_params()
+    e.time_vs_flux_on_optical_psf_vary_obscuration()
+    e.time_vs_flux_on_optical_psf_vary_lam_over_diam()
     # e.fft_image_size_vs_flux_vary_lam_over_diam()
 
 

--- a/experiments/experiments.py
+++ b/experiments/experiments.py
@@ -834,7 +834,7 @@ class Experiment:
             - Perform photon shooting using the compute_phot_draw_times() routine without any parameters on a Timer object.
             - Plot image size vs. flux.
         """
-
+        exp_num = 8
         if plot is None:
             fig, [ax, ax2] = plt.subplots(1, 2)
         else:
@@ -911,7 +911,33 @@ class Experiment:
             plt.show()
 
         if self.save:
-            self.save_figure(fig, 8)
+            self.save_figure(fig, exp_num)
+
+
+    def fft_draw_time_vs_image_size_consolidated(self):
+        """
+        experiment_9
+
+        Experiment: After running all the previous routines, plot the 
+        consolidated plot of FFT drawing times vs. image size.
+        """
+        exp_num = 9
+        method="phot"
+        self.time_vs_flux_on_gal_size(method=method)
+        self.time_vs_flux_on_gal_shape(method=method)
+        self.time_vs_flux_on_profile(method=method)
+        self.time_vs_flux_on_psf(method=method)
+        self.time_vs_flux_on_optical_psf_params(method=method)
+        self.time_vs_flux_on_optical_psf_vary_obscuration(method=method)
+        self.time_vs_flux_on_optical_psf_vary_lam_over_diam(method=method)
+
+        self.plot_fft_draw_time_vs_image_size(
+            self.fft_draw_times,
+            self.fft_draw_time_stdev,
+            self.fft_image_sizes,
+            exp_num,
+        )
+
 
 
     def run_all(self, method="phot"):
@@ -1018,7 +1044,14 @@ class Experiment:
                     markersize=marker_size/10)
 
         if title == "":
-            title = "FFT Image Drawing Time vs. k Image Size on Varied Parameter (%s)" % varied_data_label
+            if exp_number == 9:
+                # Experiment 9 is a special experiment because that is the 
+                # experiment where we consolidate all our experiment results.
+                # We want to use a differnet title for experiment 9 when 
+                # running this routine.
+                title = "FFT Image Drawing Time vs. k Image Size Consolidated Across All Experiments"
+            else:
+                title = "FFT Image Drawing Time vs. k Image Size on Varied Parameter (%s)" % varied_data_label
 
         ax.set_title(title, fontsize=fontsize)
         ax.set_xlabel("Image Size (Pixels)", fontsize=fontsize)
@@ -1039,6 +1072,7 @@ class Experiment:
         # where the x axis is a series of string labels.
 
         if varied_data is not None:
+
             # If the data contains an array of strings
             # dtype("<U1") is what numpy uses to indicate if an numpy array
             # contains strings
@@ -1052,12 +1086,11 @@ class Experiment:
             else:
                 ax.scatter(varied_data, image_sizes, marker_size)
 
-        ax.tick_params(labelsize=24)
-        ax.grid(True)
-        self.save_figure(fig, exp_number, filename_prefix="image_size_dependence")
+            ax.tick_params(labelsize=24)
+            ax.grid(True)
+            self.save_figure(fig, exp_number, filename_prefix="image_size_dependence")
 
 
-        
 
 class PhotonAndFFTPlottingExperiment(Experiment):
 
@@ -1124,9 +1157,10 @@ def main():
     # e.time_vs_flux_on_profile()
     # e.time_vs_flux_on_psf()
     # e.time_vs_flux_on_optical_psf_params()
-    e.time_vs_flux_on_optical_psf_vary_obscuration()
-    e.time_vs_flux_on_optical_psf_vary_lam_over_diam()
+    # e.time_vs_flux_on_optical_psf_vary_obscuration()
+    # e.time_vs_flux_on_optical_psf_vary_lam_over_diam()
     # e.fft_image_size_vs_flux_vary_lam_over_diam()
+    e.fft_draw_time_vs_image_size_consolidated()
 
 
     # e = PhotonAndFFTPlottingExperiment(exp_dat_dir="testing_horizontals")

--- a/experiments/experiments.py
+++ b/experiments/experiments.py
@@ -810,9 +810,9 @@ class Experiment:
         self.save_figure(fig, exp_number, filename_prefix="fft_draw_times")
 
         fig, ax = plt.subplots()
-        title = "Image Size Dependence on Varied Parameter (half_light_radius)"
+        title = "Image Size Dependence on Varied Parameter (%s)" % varied_data_label
         ax.set_title(title, fontsize=fontsize)
-        ax.set_xlabel("Varied Parameter (half_light_radius)", fontsize=fontsize)
+        ax.set_xlabel("Varied Parameter (%s)" % varied_data_label, fontsize=fontsize)
         ax.set_ylabel("Image Size (Pixels)", fontsize=fontsize)
         ax.scatter(varied_data, image_sizes, marker_size)
         ax.tick_params(labelsize=24)

--- a/experiments/experiments.py
+++ b/experiments/experiments.py
@@ -105,6 +105,16 @@ class Experiment:
             # - add the fft std dev to a list of std dev times
             # - add the image size to a list of image times
 
+            # This is to make sure that the compute_phot_draw_times routine in 
+            # core is idempotent. We test this comparing the output of that 
+            # routine on a new object vs an object that we have already run
+            # that routine on. Uncomment the following 3 lines 
+            # if you want to run this test.
+
+            # t = Timer(galaxy, flux_range=self.default_flux_range, **params)
+            # t.time_init()
+            # t.set_psf(psf)
+
             fft_draw_stats = self.compute_fft_draw_time_stats(t)
             fft_draw_times.append(fft_draw_stats["mean_draw_time"])
             fft_draw_time_stdev.append(fft_draw_stats["draw_time_stdev"])

--- a/experiments/experiments.py
+++ b/experiments/experiments.py
@@ -113,12 +113,6 @@ class Experiment:
         # plot the image times vs image size using the std dev list as the 
         # error bars
 
-        self.plot_fft_draw_time_vs_image_size(
-            fft_draw_times,
-            fft_draw_time_stdev,
-            fft_image_sizes,
-            1
-        )
 
         legend_labels.extend(["r = %f\n%s %s" % (r, annotation, method) for (r, annotation) in zip(half_light_radii, best_fit_equations)])
 
@@ -129,6 +123,17 @@ class Experiment:
 
         axs[0].legend(legend_labels)
         axs[1].legend(legend_labels)
+
+        fft_draw_time_title = "FFT Drawing Time vs. Image Size\nExperiment 1: Varying half_light_radius"
+        
+        self.plot_fft_draw_time_vs_image_size(
+            fft_draw_times,
+            fft_draw_time_stdev,
+            fft_image_sizes,
+            1,
+            title=fft_draw_time_title,
+            varied_data=half_light_radii
+        )
 
         if self.show:
             plt.show()
@@ -762,23 +767,40 @@ class Experiment:
         return dat
 
 
-    def plot_fft_draw_time_vs_image_size(self, draw_times, stdevs, image_sizes, exp_number):
+    def plot_fft_draw_time_vs_image_size(self, draw_times, stdevs, image_sizes, 
+                                         exp_number, title="", varied_data=None):
         """
         This routine takes in a list of draw times, stdevs, and image sizes and 
         plots them.
         """
         fig, ax = plt.subplots()
+        fontsize = 24
+        marker_size = 250
 
-        ax.errorbar(image_sizes, draw_times, yerr=stdevs, fmt="o")
+        ax.errorbar(image_sizes, np.array(draw_times)*10**6,
+                    yerr=np.array(stdevs)*10**6, fmt="o", 
+                    markersize=marker_size/10)
+
+        ax.set_title(title, fontsize=fontsize)
+        ax.set_xlabel("Image Size (Pixels)", fontsize=fontsize)
+        ax.set_ylabel(r"Time ($\mu$s)", fontsize=fontsize)
+
+        ax.tick_params(labelsize=24)
+        ax.grid(True)
         self.save_figure(fig, exp_number, filename_prefix="fft_draw_times")
 
+        fig, ax = plt.subplots()
+        title = "Image Size Dependence on Varied Parameter (half_light_radius)"
+        ax.set_title(title, fontsize=fontsize)
+        ax.set_xlabel("Varied Parameter (half_light_radius)", fontsize=fontsize)
+        ax.set_ylabel("Image Size (Pixels)", fontsize=fontsize)
+        ax.scatter(varied_data, image_sizes, marker_size)
+        ax.tick_params(labelsize=24)
+        ax.grid(True)
+        self.save_figure(fig, exp_number, filename_prefix="image_size_dependence")
+
 
         
-
-
-        
-
-
 
 class PhotonAndFFTPlottingExperiment(Experiment):
 

--- a/timer/core.py
+++ b/timer/core.py
@@ -391,6 +391,11 @@ class Timer:
             logger.info("Computing draw times for the %s profile convolved with %s for %d flux levels." % (self.cur_gal_name, self.cur_psf_disp_name, self.cur_num_intervals))
         except AttributeError as e:
             raise AttributeError(str(e) + "\nPlease set the psf first using set_psf.")
+
+        # This routine should be idempotent, so some objects need to be reset
+        # to maintain this idempotency.
+        self.rendered_images = []
+        self.final_times = []
         
 
         if self.debug:


### PR DESCRIPTION
Included an option to save the FFT draw image time vs. image size for each experiment and a routine to plot the consolidated results. 